### PR TITLE
switch to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,46 +5,16 @@
 
     <groupId>io.avaje</groupId>
     <artifactId>avaje-jsr305</artifactId>
-    <version>1.2</version>
+    <version>2.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.avaje</groupId>
-        <artifactId>java8-oss</artifactId>
-        <version>3.2</version>
+        <artifactId>java11-oss</artifactId>
+        <version>3.7</version>
     </parent>
 
     <scm>
         <developerConnection>scm:git:git@github.com:avaje/avaje-jsr305.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-
-<!--    <properties>-->
-<!--        <java.version>11</java.version>-->
-<!--    </properties>-->
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.RC1</version>
-                <executions>
-                    <execution>
-                        <id>add-module-infos</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>add-module-info</goal>
-                        </goals>
-                        <configuration>
-                            <jvmVersion>9</jvmVersion>
-                            <module>
-                                <moduleInfoFile>src/main/java9/module-info.java</moduleInfoFile>
-                            </module>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module io.avaje.jsr305x {
+    exports javax.annotation;
+    exports javax.annotation.meta;
+}

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,3 +1,0 @@
-module io.avaje.jsr305x {
-    exports javax.annotation;
-}


### PR DESCRIPTION
Some tools (like eclipse https://bugs.eclipse.org/bugs/show_bug.cgi?id=536273 ) cannot detect the module-info.class in META-INF/versions/9.
I think it would be a good idea to switch here completely to java 11.
(Note: multiple PRs will follow)